### PR TITLE
Enable the landscape orientation

### DIFF
--- a/jspdf.js
+++ b/jspdf.js
@@ -1136,14 +1136,14 @@ var jsPDF = (function(global) {
 				height = width[1];
 				width = width[0];
 			}
-			//if (orientation) {
-			//	switch(orientation.substr(0,1)) {
-			//		case 'l': if (height > width ) orientation = 's'; break;
-			//		case 'p': if (width > height ) orientation = 's'; break;
-			//	}
-      // TODO: What is the reason for this (for me it only seems to raise bugs)?
-			//	if (orientation === 's') { tmp = width; width = height; height = tmp; }
-			//}
+			if (orientation) {
+				switch(orientation.substr(0,1)) {
+					case 'l': if (height > width ) orientation = 's'; break;
+					case 'p': if (width > height ) orientation = 's'; break;
+				}
+      
+				if (orientation === 's') { tmp = width; width = height; height = tmp; }
+			}
 			outToPages = true;
 			pages[++page] = [];
 			pagedim[page] = {


### PR DESCRIPTION
The commented portion of code allowed the landscape orientation (a feature that I and many users need). Without that code the landscape orientation is not possible. I suggest to leave it uncommented, it doesn't seem to me that it introduces bugs at all.