### PR TITLE
fix unnecessary console warning for preexisting acroform classes

### DIFF
--- a/src/modules/acroform.js
+++ b/src/modules/acroform.js
@@ -3103,9 +3103,10 @@
     globalObj["AcroForm"] = { Appearance: AcroFormAppearance };
   } else {
     // eslint-disable-next-line no-console
-    console.warn(
-      "AcroForm-Classes are not populated into global-namespace, because the class-Names exist already. This avoids conflicts with the already used framework."
-    );
+    //console.warn(
+    //  "AcroForm-Classes are not populated into global-namespace, because the class-Names exist already. This avoids conflicts with the already used framework."
+    //);
+    // TODO this warning isn't helpful in most cases and clutters the console, find an alternative to deal with this discretely or avoid global modules entirely.
   }
 
   jsPDFAPI.AcroFormChoiceField = AcroFormChoiceField;


### PR DESCRIPTION
... in global namespace

This solves #31 by eliminating the console warning.
As discussed in #31, ultimately a wider solution of avoiding global namespace should be considered, but not having the console warning seems like an overall improvement for most cases right now.

fixes #31